### PR TITLE
refactor(enrichment): replace per-group snippet limit with per-node limit

### DIFF
--- a/src/main/java/com/example/mrrag/review/strategy/impl/AdditionContextStrategy.java
+++ b/src/main/java/com/example/mrrag/review/strategy/impl/AdditionContextStrategy.java
@@ -19,6 +19,10 @@ import java.util.stream.Collectors;
  *
  * <p>All emitted snippets carry {@link EnrichmentSnippet.LineContext#ADD}.
  *
+ * <p>Snippet budget is applied <em>per GraphNode</em> (see {@code maxSnippetsPerNode}):
+ * each node in the union independently collects up to that many snippets so that
+ * all changed nodes get context regardless of how large the union is.
+ *
  * <p>In addition to outgoing INVOKES/READS_FIELD/WRITES_FIELD edges, this strategy also:
  * <ul>
  *   <li>Adds a {@link EnrichmentSnippet.SnippetType#CLASS_DECLARATION} snippet for the
@@ -26,19 +30,20 @@ import java.util.stream.Collectors;
  *   <li>Follows outgoing EXTENDS edges to surface parent class declarations.</li>
  *   <li>Follows outgoing IMPLEMENTS edges to surface implemented interface declarations.</li>
  *   <li>Follows outgoing INSTANTIATES / INSTANTIATES_ANONYMOUS edges to surface constructor
- *       declarations. Note: the CLASS_DECLARATION deduplication in
- *       {@link ContextStrategy#filterAlreadyInDiff} will drop the METHOD_DECLARATION produced
- *       here when a CLASS_DECLARATION for the same location was already collected in Pass 1,
- *       so there is no redundancy for classes that appear both as DECLARES targets and
- *       INSTANTIATES targets.</li>
+ *       declarations.</li>
  * </ul>
  */
 @Slf4j
 @Component
 public class AdditionContextStrategy implements ContextStrategy {
 
-    @Value("${app.enrichment.maxSnippetsPerGroup:12}")
-    private int maxSnippetsPerGroup;
+    /**
+     * Maximum number of enrichment snippets collected per GraphNode.
+     * Each node in the union independently counts toward this limit so that
+     * every changed node is guaranteed to produce at least some context.
+     */
+    @Value("${app.enrichment.maxSnippetsPerNode:3}")
+    private int maxSnippetsPerNode;
 
     @Override
     public List<EnrichmentSnippet> collectContext(
@@ -48,16 +53,19 @@ public class AdditionContextStrategy implements ContextStrategy {
 
         List<EnrichmentSnippet> snippets = new ArrayList<>();
         Set<String> seenDecl = new HashSet<>();
+        // per-node snippet counter: nodeId -> count emitted for that node
+        Map<String, Integer> snippetsPerNode = new HashMap<>();
 
         // Pass 1: declaring classes for every method/field/constructor node in the union
         for (GraphNode node : union.graphNodes()) {
-            if (snippets.size() >= maxSnippetsPerGroup) break;
             if (node.kind() != NodeKind.METHOD && node.kind() != NodeKind.FIELD
                     && node.kind() != NodeKind.CONSTRUCTOR) continue;
 
             List<ChangedLine> origins = union.nodeOrigins().getOrDefault(node, List.of());
             boolean hasAdd = origins.stream().anyMatch(l -> l.type() == ChangedLine.LineType.ADD);
             if (!hasAdd) continue;
+
+            if (snippetsPerNode.getOrDefault(node.id(), 0) >= maxSnippetsPerNode) continue;
 
             sourceGraph.incoming(node.id()).stream()
                     .filter(e -> e.kind() == EdgeKind.DECLARES)
@@ -68,16 +76,17 @@ public class AdditionContextStrategy implements ContextStrategy {
                             || cls.kind() == NodeKind.ANNOTATION)
                     .filter(cls -> seenDecl.add("CLASS:" + cls.id()))
                     .findFirst()
-                    .ifPresent(cls -> snippets.add(EnrichmentSnippet.ofDeclaration(
-                            EnrichmentSnippet.SnippetType.CLASS_DECLARATION, cls,
-                            "Declaring class of changed method/field '" + node.simpleName() + "'",
-                            EnrichmentSnippet.LineContext.ADD)));
+                    .ifPresent(cls -> {
+                        snippets.add(EnrichmentSnippet.ofDeclaration(
+                                EnrichmentSnippet.SnippetType.CLASS_DECLARATION, cls,
+                                "Declaring class of changed method/field '" + node.simpleName() + "'",
+                                EnrichmentSnippet.LineContext.ADD));
+                        snippetsPerNode.merge(node.id(), 1, Integer::sum);
+                    });
         }
 
         // Pass 2: outgoing edges from union nodes
         for (GraphNode node : union.graphNodes()) {
-            if (snippets.size() >= maxSnippetsPerGroup) break;
-
             List<ChangedLine> origins = union.nodeOrigins().getOrDefault(node, List.of());
             boolean hasAdd = origins.stream().anyMatch(l -> l.type() == ChangedLine.LineType.ADD);
             if (!hasAdd) continue;
@@ -88,7 +97,7 @@ public class AdditionContextStrategy implements ContextStrategy {
                     .collect(Collectors.toSet());
 
             for (GraphEdge edge : sourceGraph.outgoing(node.id())) {
-                if (snippets.size() >= maxSnippetsPerGroup) break;
+                if (snippetsPerNode.getOrDefault(node.id(), 0) >= maxSnippetsPerNode) break;
 
                 if (edge.startLine() > 0 && !addLines.contains(edge.startLine())) continue;
 
@@ -98,45 +107,53 @@ public class AdditionContextStrategy implements ContextStrategy {
                 GraphNode target = sourceGraph.nodes.get(targetId);
                 if (target == null) continue;
 
-                switch (edge.kind()) {
-                    case INVOKES -> snippets.add(EnrichmentSnippet.ofDeclaration(
+                EnrichmentSnippet snippet = switch (edge.kind()) {
+                    case INVOKES -> EnrichmentSnippet.ofDeclaration(
                             EnrichmentSnippet.SnippetType.METHOD_DECLARATION, target,
                             "Declaration of method '" + target.simpleName() + "' called in added code",
-                            EnrichmentSnippet.LineContext.ADD));
-                    case INSTANTIATES, INSTANTIATES_ANONYMOUS -> snippets.add(EnrichmentSnippet.ofDeclaration(
+                            EnrichmentSnippet.LineContext.ADD);
+                    case INSTANTIATES, INSTANTIATES_ANONYMOUS -> EnrichmentSnippet.ofDeclaration(
                             EnrichmentSnippet.SnippetType.METHOD_DECLARATION, target,
                             "Constructor of '" + target.simpleName() + "' instantiated in added code",
-                            EnrichmentSnippet.LineContext.ADD));
-                    case READS_FIELD, WRITES_FIELD -> snippets.add(EnrichmentSnippet.ofDeclaration(
+                            EnrichmentSnippet.LineContext.ADD);
+                    case READS_FIELD, WRITES_FIELD -> EnrichmentSnippet.ofDeclaration(
                             EnrichmentSnippet.SnippetType.FIELD_DECLARATION, target,
                             "Declaration of field '" + target.simpleName() + "' accessed in added code",
-                            EnrichmentSnippet.LineContext.ADD));
-                    case READS_LOCAL_VAR, WRITES_LOCAL_VAR -> snippets.add(EnrichmentSnippet.ofDeclaration(
+                            EnrichmentSnippet.LineContext.ADD);
+                    case READS_LOCAL_VAR, WRITES_LOCAL_VAR -> EnrichmentSnippet.ofDeclaration(
                             EnrichmentSnippet.SnippetType.VARIABLE_DECLARATION, target,
                             "Declaration of variable '" + target.simpleName() + "' used in added code",
-                            EnrichmentSnippet.LineContext.ADD));
+                            EnrichmentSnippet.LineContext.ADD);
                     case EXTENDS -> {
                         if (target.kind() == NodeKind.CLASS || target.kind() == NodeKind.INTERFACE) {
-                            snippets.add(EnrichmentSnippet.ofDeclaration(
+                            yield EnrichmentSnippet.ofDeclaration(
                                     EnrichmentSnippet.SnippetType.CLASS_DECLARATION, target,
                                     "Parent class '" + target.simpleName() + "' extended by changed class",
-                                    EnrichmentSnippet.LineContext.ADD));
+                                    EnrichmentSnippet.LineContext.ADD);
                         }
+                        yield null;
                     }
                     case IMPLEMENTS -> {
                         if (target.kind() == NodeKind.INTERFACE) {
-                            snippets.add(EnrichmentSnippet.ofDeclaration(
+                            yield EnrichmentSnippet.ofDeclaration(
                                     EnrichmentSnippet.SnippetType.CLASS_DECLARATION, target,
                                     "Interface '" + target.simpleName() + "' implemented by changed class",
-                                    EnrichmentSnippet.LineContext.ADD));
+                                    EnrichmentSnippet.LineContext.ADD);
                         }
+                        yield null;
                     }
-                    default -> { }
+                    default -> null;
+                };
+
+                if (snippet != null) {
+                    snippets.add(snippet);
+                    snippetsPerNode.merge(node.id(), 1, Integer::sum);
                 }
             }
         }
 
-        log.debug("AdditionContextStrategy: union={} snippets={}", union.id(), snippets.size());
+        log.debug("AdditionContextStrategy: union={} nodes={} snippets={}",
+                union.id(), union.graphNodes().size(), snippets.size());
         return filterAlreadyInDiff(union, snippets);
     }
 }

--- a/src/main/java/com/example/mrrag/review/strategy/impl/DeletionContextStrategy.java
+++ b/src/main/java/com/example/mrrag/review/strategy/impl/DeletionContextStrategy.java
@@ -25,6 +25,10 @@ import java.util.*;
  * for the declaring class of each deleted method/field node so the LLM understands
  * the class context of the deletion.
  *
+ * <p>Snippet budget is applied <em>per GraphNode</em> (see {@code maxSnippetsPerNode}):
+ * each node in the union independently collects up to that many snippets so that
+ * all deleted nodes get context regardless of how large the union is.
+ *
  * <p>For {@code METHOD_CALLERS} / {@code FIELD_USAGES} snippets only the
  * call-site window (±{@code app.enrichment.callerWindowLines} lines) is
  * included — not the entire caller method body.
@@ -33,8 +37,12 @@ import java.util.*;
 @Component
 public class DeletionContextStrategy implements ContextStrategy {
 
-    @Value("${app.enrichment.maxSnippetsPerGroup:12}")
-    private int maxSnippetsPerGroup;
+    /**
+     * Maximum number of enrichment snippets collected per GraphNode.
+     * Each node in the union independently counts toward this limit.
+     */
+    @Value("${app.enrichment.maxSnippetsPerNode:3}")
+    private int maxSnippetsPerNode;
 
     @Value("${app.enrichment.maxCallersPerNode:5}")
     private int maxCallersPerNode;
@@ -51,16 +59,19 @@ public class DeletionContextStrategy implements ContextStrategy {
         List<EnrichmentSnippet> snippets = new ArrayList<>();
         Set<String> seenCaller = new HashSet<>();
         Set<String> seenClass = new HashSet<>();
+        // per-node snippet counter: nodeId -> count emitted for that node
+        Map<String, Integer> snippetsPerNode = new HashMap<>();
 
         // Pass 1: declaring classes for deleted method/field/constructor nodes
         for (GraphNode node : union.graphNodes()) {
-            if (snippets.size() >= maxSnippetsPerGroup) break;
             if (node.kind() != NodeKind.METHOD && node.kind() != NodeKind.FIELD
                     && node.kind() != NodeKind.CONSTRUCTOR) continue;
 
             List<ChangedLine> origins = union.nodeOrigins().getOrDefault(node, List.of());
             boolean hasDel = origins.stream().anyMatch(l -> l.type() == ChangedLine.LineType.DELETE);
             if (!hasDel) continue;
+
+            if (snippetsPerNode.getOrDefault(node.id(), 0) >= maxSnippetsPerNode) continue;
 
             GraphNode targetNode = targetGraph.nodes.get(node.id());
             if (targetNode == null) continue;
@@ -74,16 +85,17 @@ public class DeletionContextStrategy implements ContextStrategy {
                             || cls.kind() == NodeKind.ANNOTATION)
                     .filter(cls -> seenClass.add("CLASS:" + cls.id()))
                     .findFirst()
-                    .ifPresent(cls -> snippets.add(EnrichmentSnippet.ofDeclaration(
-                            EnrichmentSnippet.SnippetType.CLASS_DECLARATION, cls,
-                            "Declaring class of deleted method/field '" + node.simpleName() + "'",
-                            EnrichmentSnippet.LineContext.DELETE)));
+                    .ifPresent(cls -> {
+                        snippets.add(EnrichmentSnippet.ofDeclaration(
+                                EnrichmentSnippet.SnippetType.CLASS_DECLARATION, cls,
+                                "Declaring class of deleted method/field '" + node.simpleName() + "'",
+                                EnrichmentSnippet.LineContext.DELETE));
+                        snippetsPerNode.merge(node.id(), 1, Integer::sum);
+                    });
         }
 
         // Pass 2: callers/readers of deleted nodes
         for (GraphNode node : union.graphNodes()) {
-            if (snippets.size() >= maxSnippetsPerGroup) break;
-
             List<ChangedLine> origins = union.nodeOrigins().getOrDefault(node, List.of());
             boolean hasDel = origins.stream().anyMatch(l -> l.type() == ChangedLine.LineType.DELETE);
             if (!hasDel) continue;
@@ -96,17 +108,19 @@ public class DeletionContextStrategy implements ContextStrategy {
                     .toList();
             if (usageEdges.isEmpty()) continue;
 
+            EnrichmentSnippet.SnippetType snippetType = targetNode.kind() == NodeKind.FIELD
+                    ? EnrichmentSnippet.SnippetType.FIELD_USAGES
+                    : EnrichmentSnippet.SnippetType.METHOD_CALLERS;
+
+            int callerCount = 0;
             for (GraphEdge edge : usageEdges) {
-                if (snippets.size() >= maxSnippetsPerGroup) break;
+                if (snippetsPerNode.getOrDefault(node.id(), 0) >= maxSnippetsPerNode) break;
+                if (callerCount >= maxCallersPerNode) break;
 
                 GraphNode caller = targetGraph.nodes.get(edge.caller());
                 if (caller == null || caller.kind() != NodeKind.METHOD) continue;
 
                 if (!seenCaller.add(caller.id())) continue;
-
-                EnrichmentSnippet.SnippetType snippetType = targetNode.kind() == NodeKind.FIELD
-                        ? EnrichmentSnippet.SnippetType.FIELD_USAGES
-                        : EnrichmentSnippet.SnippetType.METHOD_CALLERS;
 
                 String window   = CallerSnippetExtractor.extract(caller, edge.startLine(), callerWindowLines);
                 int    winStart = CallerSnippetExtractor.windowStartLine(caller, edge.startLine(), callerWindowLines);
@@ -120,10 +134,13 @@ public class DeletionContextStrategy implements ContextStrategy {
                         "'" + caller.simpleName() + "' calls deleted '" + targetNode.simpleName() + "'",
                         EnrichmentSnippet.LineContext.DELETE
                 ));
+                snippetsPerNode.merge(node.id(), 1, Integer::sum);
+                callerCount++;
             }
         }
 
-        log.debug("DeletionContextStrategy: union={} snippets={}", union.id(), snippets.size());
+        log.debug("DeletionContextStrategy: union={} nodes={} snippets={}",
+                union.id(), union.graphNodes().size(), snippets.size());
         return snippets;
     }
 }

--- a/src/main/java/com/example/mrrag/review/strategy/impl/NodeImpactContextStrategy.java
+++ b/src/main/java/com/example/mrrag/review/strategy/impl/NodeImpactContextStrategy.java
@@ -19,6 +19,10 @@ import java.util.*;
  * follows <em>incoming</em> edges to surface callers and field-readers that are
  * affected by the change.
  *
+ * <p>Snippet budget is applied <em>per GraphNode</em> via {@code maxCallersPerNode}:
+ * each node in the union independently collects up to that many caller snippets
+ * so that all changed nodes get impact context regardless of union size.
+ *
  * <p>For {@code METHOD_CALLERS} / {@code FIELD_USAGES} snippets only the
  * call-site window (±{@code app.enrichment.callerWindowLines} lines) is
  * included — not the entire caller method body.
@@ -26,9 +30,6 @@ import java.util.*;
 @Slf4j
 @Component
 public class NodeImpactContextStrategy implements ContextStrategy {
-
-    @Value("${app.enrichment.maxSnippetsPerGroup:12}")
-    private int maxSnippetsPerGroup;
 
     @Value("${app.enrichment.maxCallersPerNode:5}")
     private int maxCallersPerNode;
@@ -46,7 +47,6 @@ public class NodeImpactContextStrategy implements ContextStrategy {
         Set<String> seenKey = new HashSet<>();
 
         for (GraphNode node : union.graphNodes()) {
-            if (snippets.size() >= maxSnippetsPerGroup) break;
             if (node.kind() != NodeKind.METHOD && node.kind() != NodeKind.FIELD) continue;
 
             List<ChangedLine> origins = union.nodeOrigins().getOrDefault(node, List.of());
@@ -73,7 +73,8 @@ public class NodeImpactContextStrategy implements ContextStrategy {
             }
         }
 
-        log.debug("NodeImpactContextStrategy: union={} snippets={}", union.id(), snippets.size());
+        log.debug("NodeImpactContextStrategy: union={} nodes={} snippets={}",
+                union.id(), union.graphNodes().size(), snippets.size());
         return snippets;
     }
 
@@ -98,7 +99,6 @@ public class NodeImpactContextStrategy implements ContextStrategy {
 
         int count = 0;
         for (GraphEdge edge : incoming) {
-            if (snippets.size() >= maxSnippetsPerGroup) break;
             if (count >= maxCallersPerNode) break;
 
             String key = edge.caller() + "#" + lineContext;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,8 +37,10 @@ app:
       dir: ${app.workspace.dir}/graph-cache
   enrichment:
     surroundingLines: 3
-    maxSnippetsPerGroup: 20
+    maxSnippetsPerNode: 3
     maxSnippetLines: 30
+    maxCallersPerNode: 5
+    callerWindowLines: 5
 
 graph:
   edge:


### PR DESCRIPTION
## Проблема

Единый лимит `maxSnippetsPerGroup` применялся ко всему `UnionLine` целиком. При большом числе нод в union (например, CROSS_SCOPE группа с 4 файлами) первые 1-2 ноды съедали весь лимит, и остальные ноды не получали никакого контекста. Например, `T3132` не попадал в снипеты, хотя вызывался в нескольких файлах.

## Решение

Лимит перенесён с уровня `union` на уровень `GraphNode`: каждая нода независимо собирает до `maxSnippetsPerNode` снипетов. Это гарантирует, что **все** изменённые ноды получают контекст вне зависимости от размера union.

## Изменения

### `AdditionContextStrategy`
- Удалён глобальный `maxSnippetsPerGroup` + `break` по лимиту
- Добавлен `maxSnippetsPerNode` (`@Value ${app.enrichment.maxSnippetsPerNode:3}`)
- Добавлен `Map<String, Integer> snippetsPerNode` — счётчик на ноду в Pass 1 и Pass 2

### `DeletionContextStrategy`
- Аналогично Addition: `maxSnippetsPerGroup` → `maxSnippetsPerNode` + `snippetsPerNode`
- В Pass 2 два независимых лимита: `snippetsPerNode` и `maxCallersPerNode`

### `NodeImpactContextStrategy`
- Удалён `maxSnippetsPerGroup` и его внешний `break`
- `maxCallersPerNode` уже работает per-node — этого достаточно

### `application.yml`
- Удалён `maxSnippetsPerGroup: 20`
- Добавлены: `maxSnippetsPerNode: 3`, `maxCallersPerNode: 5`, `callerWindowLines: 5`

## Эффект

| Было | Стало |
|------|-------|
| 20 снипетов на весь union | 3 снипета на каждую ноду |
| Первые ноды съедают весь лимит | Все ноды гарантированно получают контекст |
| `T3132` пропадает при 10+ нодах | Каждая нода включая `T3132` получает до 3 снипетов |
